### PR TITLE
fix: added filetype to md links so they work on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Altoids tin build option is more difficult than the 3D printed case option; 
 
 **Important: Read through all the instructions thoroughly before building. This is an intermediate level project and we don't recommend attempting it without prior electronics kit building experience.**
 
-Build instructions for both options start with the [hardware build guide](./hardware_build).
+Build instructions for both options start with the [hardware build guide](./hardware_build.md).
 
 ## license
 

--- a/hardware_build.md
+++ b/hardware_build.md
@@ -180,9 +180,9 @@ Disconnect both the USB-C cable and the battery.
 
 ## next steps
 
-Follow the [software setup guide](./software_setup) to install RetroPie on the Raspberry Pi and verify functionality.
+Follow the [software setup guide](./software_setup.md) to install RetroPie on the Raspberry Pi and verify functionality.
 
 Once you have installed RetroPie and verified that the hardware is working, continue to the final assembly guide for your build option.
 
-- [final assembly - 3D printed case version](./3dp_assembly)
-- [final assembly - Altoids tin version](./altoids_assembly)
+- [final assembly - 3D printed case version](./3dp_assembly.md)
+- [final assembly - Altoids tin version](./altoids_assembly.md)

--- a/software_setup.md
+++ b/software_setup.md
@@ -1,6 +1,6 @@
 # Pi Tin Software Setup
 
-For convenience, we provide a SD card image based on [RetroPie 4.8](https://retropie.org.uk/download/) with all required software installed and configured. This guide assumes you are using the prebuilt image. If not, full instructions for installing the required software on top of a clean install of RetroPie are [here](./full_software_setup).
+For convenience, we provide a SD card image based on [RetroPie 4.8](https://retropie.org.uk/download/) with all required software installed and configured. This guide assumes you are using the prebuilt image. If not, full instructions for installing the required software on top of a clean install of RetroPie are [here](./full_software_setup.md).
 
 ## 1. install the prebuilt image
 
@@ -62,5 +62,5 @@ input_volume_down_axis = "+1"
 
 Once you have installed and configured RetroPie and verified that the hardware is working, continue to the final assembly guide for your build option.
 
-- [final assembly - 3D printed case version](./3dp_assembly)
-- [final assembly - Altoids tin version](./altoids_assembly)
+- [final assembly - 3D printed case version](./3dp_assembly.md)
+- [final assembly - Altoids tin version](./altoids_assembly.md)


### PR DESCRIPTION
I noticed that clicking the hardware instructions link in the readme on Github lead to a 404. I considered making an issue but it was pretty trivial to fix, so...

changes: added .md to all readme links